### PR TITLE
Switch to kotlinc for running script

### DIFF
--- a/adb-event-mirror.main.kts
+++ b/adb-event-mirror.main.kts
@@ -1,4 +1,4 @@
-#!/usr/bin/env kotlin
+#!/usr/bin/env -S kotlinc -script --
 
 @file:DependsOn("com.github.ajalt:clikt:2.8.0")
 


### PR DESCRIPTION
This allows using "--" to delimit arguments which means we can use flags in the script now.