### PR TITLE
Sort input device number numerically

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yaml]
+indent_style = space

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,17 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - run: sudo snap install --classic kotlin
+      - run: ./adb-event-mirror.main.kts --test

--- a/adb-event-mirror.main.kts
+++ b/adb-event-mirror.main.kts
@@ -61,6 +61,12 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 	}
 
 	fun parseInputDevices(output: String): Map<Int, String> {
+		fun isDeviceNumberLower(old: String, new: String): Boolean {
+			val oldNumber = old.substringAfter("/event").toInt()
+			val newNumber = new.substringAfter("/event").toInt()
+			return newNumber < oldNumber
+		}
+
 		val inputDevices = mutableMapOf<Int, String>()
 		var lastInputDevice: String? = null
 		for (line in output.lines()) {
@@ -74,7 +80,7 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 				}
 				val type = match.groupValues[1].toInt(16) // TODO is this actually hex here?
 				val previous = inputDevices[type]
-				if (previous == null || lastInputDevice!! < previous) {
+				if (previous == null || isDeviceNumberLower(previous, lastInputDevice!!)) {
 					inputDevices[type] = lastInputDevice!!
 				}
 			}
@@ -217,7 +223,7 @@ class AdbEventMirrorTest {
 			|""".trimMargin())
 		val expected = mapOf(
 			1 to "/dev/input/event1",
-			3 to "/dev/input/event10",
+			3 to "/dev/input/event2",
 			4 to "/dev/input/event1",
 			17 to "/dev/input/event1"
 		)


### PR DESCRIPTION
Previously we were comparing lexicographically which sorts '10' above '2'.

Closes #13 