### PR TITLE
Fix CHANGELOG links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
 ## [Unreleased]
-[Unreleased]: https://github.com/JakeWharton/diffuse/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/JakeWharton/adb-event-mirror/compare/1.0.0...HEAD
 
 
 ## [1.0.0] - 2020-07-14
-[1.0.0]: https://github.com/JakeWharton/diffuse/releases/tag/1.0.0
+[1.0.0]: https://github.com/JakeWharton/adb-event-mirror/releases/tag/1.0.0
 
 Initial release


### PR DESCRIPTION
Links in the changelog were redirecting to diffuse instead of this repository
