### PR TITLE
Fixed Issue-21 Broken script due to wrong event mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ List of devices attached
 emulator-5554	device
 emulator-5556	device
 
-$ adb -s emulator-5554 shell getevent | /path/to/adb-event-mirror.main.kts emulator-5556
+$ adb -s emulator-5554 shell getevent | /path/to/adb-event-mirror.main.kts emulator-5554 emulator-5556
 ready!
 
 EVENT /dev/input/event1 3 57 0

--- a/adb-event-mirror.main.kts
+++ b/adb-event-mirror.main.kts
@@ -80,7 +80,6 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 			}
 			nameLine.matchEntire(line)?.let { match ->
 				val name = match.groupValues[1].split("\"")[1] // Ignoring the " at the start and end
-				println("name: $lastInputDevice , $name")
 				inputDevices.put(lastInputDevice!!, name)
 			}
 		}

--- a/adb-event-mirror.main.kts
+++ b/adb-event-mirror.main.kts
@@ -78,16 +78,6 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 			addDeviceLine.matchEntire(line)?.let { match ->
 				lastInputDevice = match.groupValues[1]
 			}
-			eventTypeLine.matchEntire(line)?.let { match ->
-				if (lastInputDevice!!.endsWith("/event0")) {
-					// Ignore 'event0' as a quick hack. TODO actually map event codes too.
-					return@let
-				}
-				val type = match.groupValues[1].toInt(16) // TODO is this actually hex here?
-				val previous = inputDevices[type]
-				if (previous == null || isDeviceNumberLower(previous, lastInputDevice!!)) {
-					inputDevices[type] = lastInputDevice!!
-				}
 			nameLine.matchEntire(line)?.let { match ->
 				val name = match.groupValues[1].split("\"")[1] // Ignoring the " at the start and end
 				println("name: $lastInputDevice , $name")
@@ -184,7 +174,6 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 	}
 
 	private val addDeviceLine = Regex("""add device \d+: (.+)""")
-	private val eventTypeLine = Regex("""    [A-Z]+ \((\d+)\): .*""")
 	private val nameLine = Regex(""" *name:(.+)""")
 	private val eventLine = Regex("""(/dev/input/[^:]+): ([0-9a-f]+) ([0-9a-f]+) ([0-9a-f]+)""")
 }

--- a/adb-event-mirror.main.kts
+++ b/adb-event-mirror.main.kts
@@ -23,12 +23,15 @@ if (args.contentEquals(arrayOf("--test"))) {
 object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 	private val debug by option("--debug", help = "Enable debug logging").flag()
 	private val showTouches by option("--show-touches").flag("--hide-touches", default = true)
-	private val mirrorSerials by argument(name = "MIRROR_SERIAL")
+	private val deviceSerials by argument(name = "DEVICE_SERIALS")
 		.multiple(true)
 		.transformAll { it.toSet() }
 
 	override fun run() {
-		val mirrors = mirrorSerials.map(::createConnection)
+		if(deviceSerials.size < 2) {
+			throw Throwable("Please pass at least 2 device serials. For example, HostSerial MirrorSerial [AnotherMirrorSerial]...")
+		}
+		val host = deviceSerials.first()
 
 		println("ready!\n")
 

--- a/adb-event-mirror.main.kts
+++ b/adb-event-mirror.main.kts
@@ -56,7 +56,7 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 					println("EVENT $input $type $code $value")
 				}
 				for (mirror in mirrors) {
-					mirror.sendEvent(input, type, code, value)
+					mirror.sendEvent(hostMapping[input] ?: input, type, code, value)
 				}
 			}
 
@@ -156,7 +156,7 @@ object AdbEventMirrorCommand : CliktCommand(name = "adb-event-mirror") {
 
 			override fun sendEvent(hostInputDevice: String, type: Int, code: Long, value: Long) {
 				val inputDevice = hostInputToSelfInput.computeIfAbsent(hostInputDevice) {
-					val result = inputDevices.getValue(type)
+					val result = inputDevices.filter { it.value == hostInputDevice }.keys.first()
 					if (debug) {
 						println("[$serial] $result will be used for host $it")
 					}


### PR DESCRIPTION
**Problem:**
The mapping of the input events is not always the same for every emulator. For example, in my case, the `/dev/input/event3` (virtio_input_multi_touch_1) from host emulator was mapped to `/dev/input/event10` (virtio_input_multi_touch_8) to mirror emulator using the event type alone.

**Solution:**
Compute the event type to name mapping for the host and mirror serials and perform a lookup for the correct mirror event type.

**Downside:**
In order to compute the mapping of the host, the host serial has to be provided in the script command.

**Next steps:**
@JakeWharton If you approve this PR, I can create a follow-up PR to run the `adb getevent` command from the script directly.